### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MCP Server: Scalable OpenAPI Endpoint Discovery and API Request Tool
 
+[![smithery badge](https://smithery.ai/badge/@baryhuang/mcp-server-any-openapi)](https://smithery.ai/server/@baryhuang/mcp-server-any-openapi)
+
 **Production-grade solution for API spec analysis** - An async FastAPI service that indexes and queries OpenAPI endpoints using endpoint-centric semantic search. Solves Claude MCP's silent failures with large specs (>100KB) through:
 - **Vectorized endpoint indexing**: 384D MiniLM-L3 embeddings (43MB) + FAISS in-memory search
 - **Streamlined parsing**: Processes 10MB specs (~5k endpoints) in <3s via parallel JSON decoding
@@ -72,6 +74,14 @@ This server specifically solves:
    - Still outperforms whole-document processing
 
 ## Installation
+
+### Installing via Smithery
+
+To install Scalable OpenAPI Endpoint Discovery and API Request Tool for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@baryhuang/mcp-server-any-openapi):
+
+```bash
+npx -y @smithery/cli install @baryhuang/mcp-server-any-openapi --client claude
+```
 
 ### Using pip
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - openapiJsonDocsUrl
+      - mcpApiPrefix
+    properties:
+      openapiJsonDocsUrl:
+        type: string
+        description: URL to the OpenAPI specification JSON.
+      mcpApiPrefix:
+        type: string
+        description: Customizable tool namespace prefix.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command: 'python', args: ['-m', 'mcp_server_any_openapi.server'], env: {OPENAPI_JSON_DOCS_URL: config.openapiJsonDocsUrl, MCP_API_PREFIX: config.mcpApiPrefix}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@baryhuang/mcp-server-any-openapi?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂