### PR TITLE
Add Xquik OpenAPI config and repair CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ Here is the multi-instance config example. I design it so it can more flexibly u
         "GLOBAL_TOOL_PROMPT='Access to insights apis for Healthcare API services efg.com .",
         "buryhuang/mcp-server-any-openapi:latest"
       ]
+    },
+    "xquik_openapi": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "OPENAPI_JSON_DOCS_URL=https://xquik.com/openapi.json",
+        "-e",
+        "MCP_API_PREFIX=xquik",
+        "-e",
+        "GLOBAL_TOOL_PROMPT='Access Xquik REST API endpoints. Include an x-api-key header when making authenticated requests.'",
+        "buryhuang/mcp-server-any-openapi:latest"
+      ]
     }
   }
 }
@@ -338,3 +353,5 @@ This project is licensed under the terms included in the LICENSE file.
   - Lazy loading of schema components
   - Parallel parsing of path items
   - Selective embedding generation (omits redundant descriptions)
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.

--- a/src/mcp_server_any_openapi/__init__.py
+++ b/src/mcp_server_any_openapi/__init__.py
@@ -7,19 +7,18 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('mcp_server_any_openapi')
 
 def main():
+    """Validate command-line arguments and start the MCP server."""
     logger.debug("Starting mcp-server-any-openapi main()")
     parser = argparse.ArgumentParser(description='Any OpenAPI MCP Server')
-    parser.add_argument('--access-token', help='Any OpenAPI access token')
-    args = parser.parse_args()
-    
-    logger.debug(f"Access token from args: {args.access_token}")
+    parser.parse_args()
+
     # Run the async main function
     logger.debug("About to run server.main()")
-    asyncio.run(server.main(args.access_token))
+    asyncio.run(server.main())
     logger.debug("Server main() completed")
 
 if __name__ == "__main__":
     main()
 
 # Expose important items at package level
-__all__ = ["main", "server"] 
+__all__ = ["main", "server"]

--- a/src/mcp_server_any_openapi/server.py
+++ b/src/mcp_server_any_openapi/server.py
@@ -45,9 +45,17 @@ class EndpointSearcher:
         """Parse schema reference and return the actual schema"""
         if not schema_ref.startswith('#/components/schemas/'):
             return {}
-        
+
         schema_name = schema_ref.split('/')[-1]
         return components['schemas'].get(schema_name, {})
+
+    def _parse_parameter_ref(self, parameter_ref: str, components: Dict) -> Dict:
+        """Parse parameter reference and return the actual parameter."""
+        if not parameter_ref.startswith('#/components/parameters/'):
+            return {}
+
+        parameter_name = parameter_ref.split('/')[-1]
+        return components.get('parameters', {}).get(parameter_name, {})
 
     def _format_schema(self, schema: Dict, components: Dict, indent: int = 0) -> str:
         """Format schema into readable text"""
@@ -103,6 +111,10 @@ class EndpointSearcher:
         if 'parameters' in operation:
             doc_parts.append("Parameters:")
             for param in operation['parameters']:
+                if '$ref' in param:
+                    param = self._parse_parameter_ref(param['$ref'], components)
+                    if not param:
+                        continue
                 param_doc = [f"  - {param['name']} ({param['in']})"]
                 if 'description' in param:
                     param_doc.append(f"    Description: {param['description']}")


### PR DESCRIPTION
## Summary

- add Xquik to the multi-instance OpenAPI configuration example
- resolve reusable OpenAPI parameter references before endpoint indexing
- use the current public OpenAPI URL, Xquik tool prefix, and authentication guidance
- remove the obsolete API base override now that the live spec uses `/api/v1` paths
- repair the installed CLI entrypoint so it calls the zero-argument async server instead of raising `TypeError`

## Validation

- `python3 -m compileall -q src`
- isolated entrypoint regression probe with and without `--access-token`
- live OpenAPI assertion for server `https://xquik.com` and `/api/v1/account`
- `git diff --check`

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.